### PR TITLE
fix: rename func_playerclip and made text corrections

### DIFF
--- a/msr/dev/halflife.fgd
+++ b/msr/dev/halflife.fgd
@@ -1266,7 +1266,7 @@
 @SolidClass base(Targetname,Renderless) = func_monsterclip : "Monster clip brush" [
 	spawnflags(flags) =
 	[
-		1: "Start ON" : 0
+		1: "Start OFF" : 0
 	]
 ]
 

--- a/msr/dev/ms1.4.fgd
+++ b/msr/dev/ms1.4.fgd
@@ -1167,11 +1167,11 @@
 	master(string) : "master"
 ]
 
-@SolidClass base(Targetname,Renderless) = func_playerclip : "Player clip brush"
+@SolidClass base(Targetname,Renderless) = ms_func_playerclip : "Player clip brush"
 [
-	dmg(integer) : "Push amount if blocked while toggling" : 0
+	dmg(integer) : "Push amount" : 0
 	spawnflags(flags) =
 	[
-		1: "Start ON" : 0
+		1: "Start OFF" : 0
 	]
 ]


### PR DESCRIPTION
Paired with PR https://github.com/MSRevive/MasterSwordRebirth/pull/212 in MSRevive

Renamed func_playerclip to ms_func_playerclip to differentiate it as a MS specific entity and made text corrections

Spawnflag in code is Start OFF, not Start ON