### PR TITLE
Fgd fixes

### DIFF
--- a/msr/dev/ms1.4.fgd
+++ b/msr/dev/ms1.4.fgd
@@ -81,6 +81,10 @@
 	targetname(target_source) : "Name"
 	note(string) : "notes"
 ]
+@BaseClass = Target 
+[ 
+	target(target_destination) : "Target" 
+]
 @BaseClass = MSRenderless
 [
 	zhlt_invisible(integer) : "Renderless" : 1
@@ -502,10 +506,6 @@
 //
 //@BaseClass size(0 0 0, 32 32 32) color(80 0 200) base(Appearflags) = Ammo []
 //
-//@BaseClass = Target 
-//[ 
-//	target(target_destination) : "Target" 
-//]
 //@BaseClass size(-16 -16 0, 16 16 32) color(0 0 200) base(Targetname, Appearflags) = Weapon []
 //@BaseClass = Global 
 //[ 

--- a/msr/dev/ms1.4.fgd
+++ b/msr/dev/ms1.4.fgd
@@ -225,10 +225,6 @@
 [
 	defscriptfile(string) : "Default Script (do not change!)" : "monsters/boar3"
 ]
-@PointClass base(ms_basenpc) color(128 0 0) studio("models/monsters/boar3.mdl") = msmonster_giantboar : "Giant Boar"
-[
-	defscriptfile(string) : "Default Script (do not change!)" : "monsters/boar3"
-]
 @PointClass base(Targetname,Angles) color(128 0 0) studio("models/monsters/ogre_cave.mdl") = msmonster_random : "Randomized Monster"
 [
 	random_1_scriptfile(string) : "#1 Script File" 

--- a/msr/dev/ms1.4.fgd
+++ b/msr/dev/ms1.4.fgd
@@ -76,6 +76,11 @@
 [
 	angles(string) : "Pitch Yaw Roll (Y Z X)" : "0 0 0"
 ]
+@BaseClass = Targetname 
+[ 
+	targetname(target_source) : "Name"
+	note(string) : "notes"
+]
 @BaseClass = MSRenderless
 [
 	zhlt_invisible(integer) : "Renderless" : 1

--- a/msr/dev/ms1.4.fgd
+++ b/msr/dev/ms1.4.fgd
@@ -85,6 +85,25 @@
 [ 
 	target(target_destination) : "Target" 
 ]
+@BaseClass base(Target, Targetname) = Trigger
+[
+	killtarget(target_destination) : "Kill target"
+	netname(target_destination) : "Target Path"
+	style(integer) : "Style" : 32
+	master(string) : "Master" 
+	sounds(choices) : "Sound style" : 0 =
+	[
+		0 : "No Sound"
+	]
+	delay(string) : "Delay before trigger" : "0"
+	message(string) : "Message (set sound too!)"
+	spawnflags(flags) = 
+	[
+		1: "Monsters" : 0
+		2: "No Clients" : 0
+		4: "Pushables": 0
+	]
+]
 @BaseClass = MSRenderless
 [
 	zhlt_invisible(integer) : "Renderless" : 1
@@ -884,26 +903,6 @@
 //	toptrack(target_destination) : "Top track"
 //	bottomtrack(target_destination) : "Bottom track"
 //	speed(integer) : "Move/Rotate speed" : 0
-//]
-//
-//@BaseClass base(Target, Targetname) = Trigger
-//[
-//	killtarget(target_destination) : "Kill target"
-//	netname(target_destination) : "Target Path"
-//	style(integer) : "Style" : 32
-//	master(string) : "Master" 
-//	sounds(choices) : "Sound style" : 0 =
-//	[
-//		0 : "No Sound"
-//	]
-//	delay(string) : "Delay before trigger" : "0"
-//	message(string) : "Message (set sound too!)"
-//	spawnflags(flags) = 
-//	[
-//		1: "Monsters" : 0
-//		2: "No Clients" : 0
-//		4: "Pushables": 0
-//	]
 //]
 
 //===================== END Halflife Base Entries

--- a/msr/dev/ms1.4.fgd
+++ b/msr/dev/ms1.4.fgd
@@ -1167,7 +1167,7 @@
 	master(string) : "master"
 ]
 
-@SolidClass base(Targetname,Renderless) = ms_func_playerclip : "Player clip brush"
+@SolidClass base(Targetname,MSRenderless) = ms_func_playerclip : "Player clip brush"
 [
 	dmg(integer) : "Push amount" : 0
 	spawnflags(flags) =


### PR DESCRIPTION
Added numerous base classes which other classes in the FGD expected to be there but weren't, resulting in errors as seen in J.A.C.K. when loading the FGD.

Also removed a duplicate giantboar def which was causing an error.

Switched from `base(...Renderless)` to `base(...MSRenderless)` for `ms_func_playerclip` to match other MS specific entities. 